### PR TITLE
Added Dead Blinks drain life

### DIFF
--- a/Mortals.ino
+++ b/Mortals.ino
@@ -91,7 +91,19 @@ void loop() {
 
     if (health > 0) {
 
-      health--;
+      byte numDeadNeighbors = 0;
+
+      //Dead Blinks will also drain life
+      FOREACH_FACE(f) {
+        if (!isValueReceivedOnFaceExpired(f)) {
+          if (getLastValueReceivedOnFace(f) == DEAD) {
+            numDeadNeighbors++;
+          }
+        }
+      }
+
+      //Remove extra health for every dead neighbor attached
+      health = (health - 1) - numDeadNeighbors;
       healthTimer.set(HEALTH_STEP_TIME_MS);
 
     } else {


### PR DESCRIPTION
Updated the game so that when attached to a blink in DEAD state, an additional second will be taken from ALIVE blinks.